### PR TITLE
Skipping checklist if status is set to denied

### DIFF
--- a/services/web/src/components/pages/Requests/components/RequestInformation/index.js
+++ b/services/web/src/components/pages/Requests/components/RequestInformation/index.js
@@ -98,7 +98,8 @@ export default function Index({
 
     let completedChecklist = isChecklistCompleted(preChecklistValues);
 
-    if (!completedChecklist) return pleaseFinishChecklistModal();
+    if (!completedChecklist && status !== 'denied')
+      return pleaseFinishChecklistModal();
 
     const handleDenial = async () => {
       console.log(request);


### PR DESCRIPTION
Users can deny a request without finishing the preapproval checklist