### PR TITLE
remove podium

### DIFF
--- a/services/web/public/index.html
+++ b/services/web/public/index.html
@@ -67,6 +67,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script defer src="https://connect.podium.com/widget.js#API_TOKEN=6f409238-bf28-45cb-81b5-d531eae38dca" id="podium-widget" data-api-token="6f409238-bf28-45cb-81b5-d531eae38dca"></script>
+ 
   </body>
 </html>

--- a/services/web/src/components/pages/Apply/index.tsx
+++ b/services/web/src/components/pages/Apply/index.tsx
@@ -126,7 +126,7 @@ export default function Index() {
 
   const goBackwards = () => setStep(step - 1);
 
-  const [formValues, setFormValues] = useState(INITIAL_VALUES_PROD);
+  const [formValues, setFormValues] = useState(INITIAL_VALUES_DEV);
   const [formConsent, setFormConsent] = useState(false);
 
   const handleChange = e => {


### PR DESCRIPTION
Functionality is only sort of impressive, they want to lock us down to 12 months to do a small upgrade that allows us to edit avatar.  Removing and staying with intercom (and potentially moving to zendesk when intercom trial is over)