### PR TITLE
Moved childrenAges from demographics to household page

### DIFF
--- a/services/web/package-lock.json
+++ b/services/web/package-lock.json
@@ -19181,6 +19181,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/services/web/src/components/pages/ApplyV2/components/forms/Demographics.tsx
+++ b/services/web/src/components/pages/ApplyV2/components/forms/Demographics.tsx
@@ -55,26 +55,6 @@ export default function Address({
           commas:
         </b>
 
-        <Form.Item
-          initialValue={formValues.childrenAges}
-          label="Children Ages"
-          name="childrenAges"
-          rules={[
-            {
-              type: 'string',
-              required: true,
-              message:
-                'Please enter the ages of any children in the household, separated by commas',
-            },
-          ]}
-        >
-          <Input
-            name="childrenAges"
-            placeholder="4, 2, etc."
-            value={formValues.childrenAges}
-          />
-        </Form.Item>
-
         <Title level={5}>Head of Household Identifies as</Title>
 
         <Form.Item label="Ethnicity:">

--- a/services/web/src/components/pages/ApplyV2/components/forms/Demographics.tsx
+++ b/services/web/src/components/pages/ApplyV2/components/forms/Demographics.tsx
@@ -232,8 +232,6 @@ const updateDemographics = async (
   dispatch
 ) => {
   const {
-    dob,
-    childrenAges,
     hispanic,
     asian,
     black,
@@ -241,11 +239,9 @@ const updateDemographics = async (
     white,
     native,
     demoNotSay,
-    gender,
   } = formValues;
 
   const demographicsInfo = {
-    childrenAges,
     hispanic,
     asian,
     black,

--- a/services/web/src/components/pages/ApplyV2/components/forms/Household.tsx
+++ b/services/web/src/components/pages/ApplyV2/components/forms/Household.tsx
@@ -145,6 +145,7 @@ const updateHousehold = async (
   const {
     familySize,
     totalChildren,
+    childrenAges,
     beds,
     monthlyIncome,
     monthlyRent,
@@ -155,6 +156,7 @@ const updateHousehold = async (
   const householdInfo = {
     familySize,
     totalChildren,
+    childrenAges,
     beds,
     monthlyIncome,
     monthlyRent,

--- a/services/web/src/components/pages/ApplyV2/components/forms/Household.tsx
+++ b/services/web/src/components/pages/ApplyV2/components/forms/Household.tsx
@@ -151,12 +151,12 @@ const updateHousehold = async (
     monthlyRent,
     owed,
     amountRequested,
-  } = formValues;
+  } = formValues; 
 
   const householdInfo = {
     familySize,
     totalChildren,
-    childrenAges,
+    childrenAges, 
     beds,
     monthlyIncome,
     monthlyRent,
@@ -165,7 +165,7 @@ const updateHousehold = async (
   };
 
   try {
-    await axiosWithAuth().put(`/requests/${request.id}`, householdInfo);
+    await axiosWithAuth().put(`/requests/${request.id}`, householdInfo); // Updates the request
 
     if (currentUser.applicationStep === 'household') {
       await axiosWithAuth()

--- a/services/web/src/components/pages/ApplyV2/components/forms/Household.tsx
+++ b/services/web/src/components/pages/ApplyV2/components/forms/Household.tsx
@@ -66,7 +66,6 @@ export default function Address({
             value={formValues.familySize}
           />
         </Form.Item>
-
         <Form.Item
           name="totalChildren"
           initialValue={formValues.totalChildren}
@@ -88,6 +87,28 @@ export default function Address({
           />
         </Form.Item>
 
+        {/*    */}
+        <Form.Item
+          initialValue={formValues.childrenAges}
+          label="Children Ages"
+          name="childrenAges"
+          rules={[
+            {
+              type: 'string',
+              required: true,
+              message:
+                'Please enter the ages of any children in the household, separated by commas',
+            },
+          ]}
+        >
+          <Input
+            name="childrenAges"
+            placeholder="4, 2, etc."
+            value={formValues.childrenAges}
+          />
+        </Form.Item>
+        {/*    */}
+
         <Form.Item
           name="beds"
           initialValue={formValues.beds}
@@ -108,7 +129,6 @@ export default function Address({
             value={formValues.beds}
           />
         </Form.Item>
-
         <Button htmlType="submit">Next</Button>
       </Card>
     </Form>


### PR DESCRIPTION
moved "input children ages"

Description:

Moved the form element for inputting children's ages from demographics over to the "your household" area where it is asking user for number of children in household. Checked and validated that the 'formValues' state variable got the appropriate values in the object.